### PR TITLE
Retry TCP commands

### DIFF
--- a/lan.cpp
+++ b/lan.cpp
@@ -157,7 +157,7 @@ int sendCommandWithRetry(const char* host, const unsigned char* code, int codeLe
     int retCode { -1 };
     int retry { 0 };
     while (retCode < 0 && retry < MAX_RETRY_COUNT) {
-        spdlog::info("sendCommandWithRetry attempt {} of {}", retry + 1, MAX_RETRY_COUNT);
+        spdlog::debug("sendCommandWithRetry attempt {} of {}", retry + 1, MAX_RETRY_COUNT);
         retCode = sendCommand(host, code, codeLen, response);
         retry++;
     }

--- a/lan.hpp
+++ b/lan.hpp
@@ -63,4 +63,15 @@ bool isOff();
  */
 int queryPowerStatus();
 
+/**
+ * Same as queryPowerStatus but caches the result for 10 seconds.
+ *
+ * This prevents many rapid calls for the power status from overloading
+ * the projector's maximum connection count (which appears quite low,
+ * empirically).
+ *
+ * @return  int     @see queryPowerStatus
+ */
+int queryPowerStatusCached();
+
 #endif


### PR DESCRIPTION
Retry TCP commands up to three times upon failure.

Sometimes a command will fail with a temporary socket error, but will succeed upon retry. /shrug/