### PR TITLE
Enforce max runtime in service file

### DIFF
--- a/cecfix.service
+++ b/cecfix.service
@@ -11,6 +11,7 @@ ExecStart={{DIR}}/build/cec-fix ${PROJECTOR_HOST_IP}
 Restart=always
 RestartSec=5
 KillSignal=SIGINT
+RuntimeMaxSec=86400
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
The drivers powering CEC sometimes stop sending events for unknown reasons. This causes the service to restart every 24 hours, which should help.